### PR TITLE
chore: Update api url and add header api key

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from ulauncher.api.shared.action.CopyToClipboardAction import CopyToClipboardAct
 
 LOGGER = logging.getLogger(__name__)
 
-CONVERTER_API_BASE_URL = 'http://data.fixer.io/api'
+CONVERTER_API_BASE_URL = 'https://api.apilayer.com/fixer'
 REGEX = r"(\d+\.?\d*)\s*([a-zA-Z]{3})\s(to|in)\s([a-zA-Z]{3})"
 
 
@@ -30,12 +30,15 @@ class CurrencyConverterExtension(Extension):
     def convert_currency(self, amount, from_currency, to_currency):
         """ Converts an amount from one currency to another """
 
+        headers = {
+            'apikey' : self.preferences['api_key']
+        }
+
         params = {
-            'access_key': self.preferences['api_key'],
             'symbols': '%s,%s' % (from_currency, to_currency)
         }
 
-        r = requests.get("%s/latest" % CONVERTER_API_BASE_URL, params=params)
+        r = requests.get("%s/latest" % CONVERTER_API_BASE_URL, headers=headers, params=params)
         response = r.json()
 
         if r.status_code != 200:


### PR DESCRIPTION
Fixer.io migrated their sign up to API Layer so all new registrations should be done over there. But not only that, the **API HOST** changed as well, even the old one is still active the newer keys created at API Layer doesn't authenticate on the old host.

This commit fixes:

- [x] Change API HOST to the new one provided by API Layer
- [x] Add 'apikey' key to the request header still preserving the use of the one set at uLauncher Extensions settings 

![image](https://user-images.githubusercontent.com/5279392/199418085-83cb2641-038e-4a6e-aaf8-169831eb7e65.png)

Working properly now:

![image](https://user-images.githubusercontent.com/5279392/199419414-0889cb9b-97fa-478b-83c7-8c6499dd1315.png)

